### PR TITLE
Modernize iccbeta and include finiteness check on design matrix (close #3)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^README-.*\.png$
 ^\.travis\.yml$
 ^cran-comments\.md$
+^src/\.clang-format$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,27 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
-# Standard devtools wrapper travis declaration
-language: r
-cache: packages
-sudo: required
+###### Default build via devtools::use_travis()
 
-# Testing matrix of different R versions
-# r:
-#   - 3.2
-#   - oldrel
-#   - release
-#   - devel
+language: r
+sudo: false
+cache: packages
+
+###### Custom Options
+
+# Containers have 2 CPUs by default. Speed up the build by using both.
+# c.f. https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
+env:
+  global:
+  - MAKEFLAGS="-j 2"
+  - _R_CHECK_FORCE_SUGGESTS_=false
+
+# Run R package on both release and developer versions
+jobs:
+  include:
+  - r: release
+  - r: devel
+  - r: oldrel
+
+# If one fails, avoid running the other.
+matrix:
+  fast_finish: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,9 +21,9 @@ Description: A function and vignettes for computing an intraclass correlation
     described in Aguinis & Culpepper (2015) <doi:10.1177/1094428114563618>.
     This package quantifies the share of variance in a dependent variable that
     is attributed to group heterogeneity in slopes.
-Imports: Rcpp (>= 0.12.12)
-LinkingTo: Rcpp (>= 0.12.12), RcppArmadillo (>= 0.7.800)
-Depends: R (>= 3.2.0)
+Imports: Rcpp 
+LinkingTo: Rcpp (>= 1.0.0), RcppArmadillo (>= 0.9.200)
+Depends: R (>= 3.4.0)
 Suggests: lme4, RLRsim
 URL: https://github.com/tmsalab/iccbeta
 BugReports: https://github.com/tmsalab/iccbeta/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,4 +24,5 @@ License: GPL (>= 2)
 URL: https://github.com/tmsalab/iccbeta
 BugReports: https://github.com/tmsalab/iccbeta/issues
 RoxygenNote: 6.1.1
+Roxygen: list(markdown = TRUE)
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,4 +24,4 @@ License: GPL (>= 2)
 URL: https://github.com/tmsalab/iccbeta
 BugReports: https://github.com/tmsalab/iccbeta/issues
 RoxygenNote: 6.1.1
-Encoding: UTF-8 
+Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,18 @@ Title: Multilevel Model Intraclass Correlation for Slope Heterogeneity
 Version: 1.1.0.1000
 Authors@R: c(person("Steven Andrew", "Culpepper", role = c("aut", "cph","cre"),
     email = "sculpepp@illinois.edu"),
-    person("Herman", "Aguinis", role = c("aut", "cph"), email =
-    "haguinis@gwu.edu"))
+    person(, role = c("aut", "cph"), email =
+    ""))
+Authors@R: c(person("Steven Andrew", "Culpepper", 
+                    email = "sculpepp@illinois.edu",
+                    role = c("aut", "cph", "cre"),
+                    comment = c(ORCID = "0000-0003-4226-6176")
+                    ),
+             person("Herman", "Aguinis"
+                    email = "haguinis@gwu.edu",
+                    role = c("aut", "cph"),
+                    comment = c(ORCID = "0000-0002-3485-9484"))
+            )
 License: GPL (>= 2)
 Description: A function and vignettes for computing an intraclass correlation
     described in Aguinis & Culpepper (2015) <doi:10.1177/1094428114563618>.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iccbeta
 Type: Package
 Title: Multilevel Model Intraclass Correlation for Slope Heterogeneity
-Version: 1.1.0.1000
+Version: 1.3.0
 Authors@R: c(person("Steven Andrew", "Culpepper", 
                     email = "sculpepp@illinois.edu",
                     role = c("aut", "cph", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(person("Steven Andrew", "Culpepper",
                     role = c("aut", "cph", "cre"),
                     comment = c(ORCID = "0000-0003-4226-6176")
                     ),
-             person("Herman", "Aguinis"
+             person("Herman", "Aguinis",
                     email = "haguinis@gwu.edu",
                     role = c("aut", "cph"),
                     comment = c(ORCID = "0000-0002-3485-9484"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iccbeta
 Type: Package
 Title: Multilevel Model Intraclass Correlation for Slope Heterogeneity
-Version: 1.3.0
+Version: 1.2.0
 Authors@R: c(person("Steven Andrew", "Culpepper", 
                     email = "sculpepp@illinois.edu",
                     role = c("aut", "cph", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,4 +23,5 @@ Suggests: lme4, RLRsim
 License: GPL (>= 2)
 URL: https://github.com/tmsalab/iccbeta
 BugReports: https://github.com/tmsalab/iccbeta/issues
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1
+Encoding: UTF-8 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,6 @@ Package: iccbeta
 Type: Package
 Title: Multilevel Model Intraclass Correlation for Slope Heterogeneity
 Version: 1.1.0.1000
-Authors@R: c(person("Steven Andrew", "Culpepper", role = c("aut", "cph","cre"),
-    email = "sculpepp@illinois.edu"),
-    person(, role = c("aut", "cph"), email =
-    ""))
 Authors@R: c(person("Steven Andrew", "Culpepper", 
                     email = "sculpepp@illinois.edu",
                     role = c("aut", "cph", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,15 +12,15 @@ Authors@R: c(person("Steven Andrew", "Culpepper",
                     role = c("aut", "cph"),
                     comment = c(ORCID = "0000-0002-3485-9484"))
             )
-License: GPL (>= 2)
 Description: A function and vignettes for computing an intraclass correlation
     described in Aguinis & Culpepper (2015) <doi:10.1177/1094428114563618>.
     This package quantifies the share of variance in a dependent variable that
     is attributed to group heterogeneity in slopes.
+Depends: R (>= 3.4.0)
 Imports: Rcpp 
 LinkingTo: Rcpp (>= 1.0.0), RcppArmadillo (>= 0.9.200)
-Depends: R (>= 3.4.0)
 Suggests: lme4, RLRsim
+License: GPL (>= 2)
 URL: https://github.com/tmsalab/iccbeta
 BugReports: https://github.com/tmsalab/iccbeta/issues
 RoxygenNote: 6.0.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,4 +2,4 @@
 
 export(icc_beta)
 importFrom(Rcpp,evalCpp)
-useDynLib("iccbeta", .registration=TRUE)
+useDynLib(iccbeta, .registration=TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# iccbeta 1.2.0
+
+## Changes
+
+- Added improved error messaging related to presence of missing values and
+  dimension mis-match.
+- Added ORCiDs to `DESCRIPTION`
+- Increased version dependencies.
+- Enabled use of OpenMP and C++11.
+- Added `CITATION` information for the _R_ package.
+
+## Documentation
+
+- Switched documentation to use Markdown.
+- Improved contents of documentation.
+
+## Deployment
+
+- Enable the default TMSALab Travis-CI configuration.
+
 # iccbeta 1.1.0
 
 - Adds instructions on how to create `simICCdata2` to relevant helpdocs

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -3,82 +3,100 @@
 
 #' Intraclass correlation used to assess variability of lower-order
 #' relationships across higher-order processes/units.
-#' 
+#'
 #' A function and vignettes for computing the intraclass correlation described
 #' in Aguinis & Culpepper (2015). iccbeta quantifies the share of variance
 #' in an outcome variable that is attributed to heterogeneity in slopes due to
-#' higher-order processes/units. 
-#' @param X    The design \code{matrix} of fixed effects from a lmer model.
-#' @param l2id A \code{vector} that identifies group membership. The vector 
-#'             must be coded as a sequence of integers from 1 to J, 
+#' higher-order processes/units.
+#' 
+#' @param X    The design `matrix` of fixed effects from a lmer model.
+#' @param l2id A `vector` that identifies group membership. The vector
+#'             must be coded as a sequence of integers from 1 to J,
 #'             the number of groups.
-#' @param T    A \code{matrix} of the estimated variance-covariance matrix of
+#' @param T    A `matrix` of the estimated variance-covariance matrix of
 #'             a lmer model fit.
 #' @param vy   The variance of the outcome variable.
-#' @return vy  The variance of the dependent variable.
-#' @author Steven A Culpepper
-#' @seealso \code{\link[lme4]{lmer}}, \code{\link{model.matrix}},
-#'          \code{\link[lme4]{VarCorr}}, \code{\link[RLRsim]{LRTSim}},
-#'          \code{\link{Hofmann}}, \code{\link{simICCdata}}
-#' @references 
+#' 
+#' @return 
+#' A `list` with:
+#' 
+#' - `J`
+#' - `means`
+#' - `XcpXc`
+#' - `Nj`
+#' - `rho_beta`
+#' 
+#' @author 
+#' Steven Andrew Culpepper
+#' 
+#' @seealso 
+#' 
+#' [lme4::lmer()], [model.matrix()],
+#' [lme4::VarCorr()], [RLRsim::LRTSim()],
+#' [iccbeta::Hofmann], and [iccbeta::simICCdata]
+#'          
+#' @references
 #' Aguinis, H., & Culpepper, S.A. (2015). An expanded decision making
 #' procedure for examining cross-level interaction effects with multilevel
-#' modeling. \emph{Organizational Research Methods}. Available at:
-#' \url{http://hermanaguinis.com/pubs.html}
+#' modeling. _Organizational Research Methods_. Available at:
+#' <http://hermanaguinis.com/pubs.html>
+#' 
 #' @export
 #' @examples
 #' \dontrun{
-#' 
-#' if(requireNamespace("lme4") && requireNamespace("RLRsim")){ 
+#'
+#' if(requireNamespace("lme4") && requireNamespace("RLRsim")){
 #' # Simulated Data Example from Aguinis & Culpepper (2015)
 #' data(simICCdata)
 #' library("lme4")
-#'     
+#'
 #' # Computing icca
 #' vy <- var(simICCdata$Y)
 #' lmm0 <- lmer(Y ~ (1 | l2id), data = simICCdata, REML = FALSE)
 #' VarCorr(lmm0)$l2id[1, 1]/vy
-#' 
+#'
 #' # Create simICCdata2
 #' grp_means = aggregate(simICCdata[c('X1', 'X2')], simICCdata['l2id'], mean)
 #' colnames(grp_means)[2:3] = c('m_X1', 'm_X2')
 #' simICCdata2 = merge(simICCdata, grp_means, by='l2id')
-#'         
+#'
 #' # Estimating random slopes model
-#' lmm1  <- lmer(Y ~ I(X1-m_X1) + I(X2-m_X2) + (I(X1-m_X1) + I(X2-m_X2) | l2id),
-#'                       data = simICCdata2, REML = FALSE)
+#' lmm1  <- lmer(Y ~ I(X1 - m_X1) + I(X2 - m_X2) + 
+#'                  (I(X1 - m_X1) + I(X2 - m_X2) | l2id),
+#'               data = simICCdata2, REML = FALSE)
+#'                   
 #' X <- model.matrix(lmm1)
 #' p <- ncol(X)
 #' T1  <- VarCorr(lmm1)$l2id[1:p,1:p]
-#' 
+#'
 #' # Computing iccb
 #' # Notice '+1' because icc_beta assumes l2ids are from 1 to 30.
 #' icc_beta(X, simICCdata2$l2id+1, T1, vy)$rho_beta
-#'             
+#'
 #' # Hofmann et al. (2000) Example
 #' data(Hofmann)
 #' library("lme4")
-#'                 
+#'
 #' # Random-Intercepts Model
 #' lmmHofmann0 = lmer(helping ~ (1|id), data = Hofmann)
 #' vy_Hofmann = var(Hofmann[,'helping'])
-#' 
+#'
 #' # Computing icca
 #' VarCorr(lmmHofmann0)$id[1,1]/vy_Hofmann
-#'                     
+#'
 #' # Estimating Group-Mean Centered Random Slopes Model, no level 2 variables
 #' lmmHofmann1 <- lmer(helping ~ mood_grp_cent + (mood_grp_cent |id),
 #'                     data = Hofmann, REML = FALSE)
 #' X_Hofmann <- model.matrix(lmmHofmann1)
 #' P <- ncol(X_Hofmann)
 #' T1_Hofmann <- VarCorr(lmmHofmann1)$id[1:P,1:P]
-#' 
+#'
 #' # Computing iccb
 #' icc_beta(X_Hofmann, Hofmann[,'id'], T1_Hofmann, vy_Hofmann)$rho_beta
-#'                         
+#'
 #' # Performing LR test
 #' library("RLRsim")
-#' lmmHofmann1a <- lmer(helping ~ mood_grp_cent + (1 |id), 
+#' lmmHofmann1a <- lmer(helping ~ mood_grp_cent + (1 |id),
 #'                      data = Hofmann, REML = FALSE)
 #' obs.LRT <- 2*(logLik(lmmHofmann1) - logLik(lmmHofmann1a))[1]
 #' X <- getME(lmmHofmann1,"X")
@@ -86,9 +104,9 @@
 #' sim.LRT <- LRTSim(X, Z, 0, diag(ncol(Z)))
 #' (pval <- mean(sim.LRT > obs.LRT))
 #' } else {
-#'  stop("Please install packages `RLRsim` and `lme4` to run the above example.")
+#'  stop("Please install packages `RLRsim` and `lme4` to run the above example.") 
+#' } 
 #' }
-#' }  
 icc_beta <- function(X, l2id, T, vy) {
     .Call(`_iccbeta_icc_beta`, X, l2id, T, vy)
 }

--- a/R/iccbeta-internal.R
+++ b/R/iccbeta-internal.R
@@ -1,6 +1,6 @@
 # Package documentation
 
-#' @useDynLib "iccbeta", .registration=TRUE
+#' @useDynLib iccbeta, .registration=TRUE
 #' @importFrom Rcpp evalCpp
 #' @references
 #' Aguinis, H., & Culpepper, S.A. (2015).

--- a/README.Rmd
+++ b/README.Rmd
@@ -12,13 +12,65 @@ knitr::opts_chunk$set(
 )
 ```
 
-[![Travis-CI Build Status](https://travis-ci.org/tmsalab/iccbeta.svg?branch=master)](https://travis-ci.org/tmsalab/iccbeta)
-[![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/iccbeta)](http://www.r-pkg.org/pkg/iccbeta)
-[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/iccbeta)](https://cran.r-project.org/package=iccbeta)
+[![Build Status](https://travis-ci.org/tmsalab/iccbeta.svg)](https://travis-ci.org/tmsalab/iccbeta)
+[![Package-License](http://img.shields.io/badge/license-GPL%20(%3E=2)-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
+[![CRAN Version Badge](http://www.r-pkg.org/badges/version/iccbeta)](https://cran.r-project.org/package=iccbeta)
+[![CRAN Status](https://cranchecks.info/badges/worst/iccbeta)](https://cran.r-project.org/web/checks/check_results_iccbeta.html)
+[![RStudio CRAN Mirror's Monthly Downloads](http://cranlogs.r-pkg.org/badges/iccbeta?color=brightgreen)](http://www.r-pkg.org/pkg/iccbeta)
+[![RStudio CRAN Mirror's Total Downloads](http://cranlogs.r-pkg.org/badges/grand-total/iccbeta?color=brightgreen)](http://www.r-pkg.org/pkg/iccbeta)
+<!--[![Coverage status](https://codecov.io/gh/tmsalab/iccbeta/branch/master/graph/badge.svg)](https://codecov.io/github/tmsalab/iccbeta?branch=master)-->
 
-# `iccbeta` R Package
+# `iccbeta` R package
 
-A function and vignettes for computing an intraclass correlation described in
-Aguinis & Culpepper (in press). iccbeta quantifies the share of variance in a
-dependent variable that is attributed to group heterogeneity in slopes.
+A function and vignettes for computing an intraclass correlation
+described in Aguinis & Culpepper (in press). iccbeta quantifies the
+share of variance in a dependent variable that is attributed to group
+heterogeneity in slopes.
 
+## Installation
+
+You can install `iccbeta` from CRAN using:
+
+```{r cran-installation, eval = FALSE}
+install.packages("iccbeta")
+```
+
+Or, you can be on the cutting-edge development version on GitHub using:
+
+```{r gh-installation, eval = FALSE}
+if(!requireNamespace("devtools")) install.packages("devtools")
+devtools::install_github("tmsalab/iccbeta")
+```
+
+## Usage
+
+To use the `iccbeta` package, load it into _R_ using:
+
+```{r example, message = FALSE}
+library("iccbeta")
+```
+
+From there, the `icc_beta()` function can be called to compute the 
+intraclass correlation:
+
+```{r sample-call, eval = FALSE}
+results = icc_beta(X, l2id, T, vy)
+```
+
+## Authors
+
+Steven Andrew Culpepper and Herman Aguinis
+
+## Citing the `iccbeta` package
+
+To ensure future development of the package, please cite `iccbeta`
+package if used during an analysis or simulation studies. Citation information
+for the package may be acquired by using in *R*:
+
+```{r, eval = FALSE}
+citation("iccbeta")
+```
+
+## License
+
+GPL (>= 2)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,70 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-[![Travis-CI Build
-Status](https://travis-ci.org/tmsalab/iccbeta.svg?branch=master)](https://travis-ci.org/tmsalab/iccbeta)
-[![CRAN RStudio mirror
-downloads](http://cranlogs.r-pkg.org/badges/iccbeta)](http://www.r-pkg.org/pkg/iccbeta)
-[![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/iccbeta)](https://cran.r-project.org/package=iccbeta)
+[![Build
+Status](https://travis-ci.org/tmsalab/iccbeta.svg)](https://travis-ci.org/tmsalab/iccbeta)
+[![Package-License](http://img.shields.io/badge/license-GPL%20\(%3E=2\)-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
+[![CRAN Version
+Badge](http://www.r-pkg.org/badges/version/iccbeta)](https://cran.r-project.org/package=iccbeta)
+[![CRAN
+Status](https://cranchecks.info/badges/worst/iccbeta)](https://cran.r-project.org/web/checks/check_results_iccbeta.html)
+[![RStudio CRAN Mirror’s Monthly
+Downloads](http://cranlogs.r-pkg.org/badges/iccbeta?color=brightgreen)](http://www.r-pkg.org/pkg/iccbeta)
+[![RStudio CRAN Mirror’s Total
+Downloads](http://cranlogs.r-pkg.org/badges/grand-total/iccbeta?color=brightgreen)](http://www.r-pkg.org/pkg/iccbeta)
+<!--[![Coverage status](https://codecov.io/gh/tmsalab/iccbeta/branch/master/graph/badge.svg)](https://codecov.io/github/tmsalab/iccbeta?branch=master)-->
 
-# `iccbeta` R Package
+# `iccbeta` R package
 
 A function and vignettes for computing an intraclass correlation
 described in Aguinis & Culpepper (in press). iccbeta quantifies the
 share of variance in a dependent variable that is attributed to group
 heterogeneity in slopes.
+
+## Installation
+
+You can install `iccbeta` from CRAN using:
+
+``` r
+install.packages("iccbeta")
+```
+
+Or, you can be on the cutting-edge development version on GitHub using:
+
+``` r
+if(!requireNamespace("devtools")) install.packages("devtools")
+devtools::install_github("tmsalab/iccbeta")
+```
+
+## Usage
+
+To use the `iccbeta` package, load it into *R* using:
+
+``` r
+library("iccbeta")
+```
+
+From there, the `icc_beta()` function can be called to compute the
+intraclass correlation:
+
+``` r
+results = icc_beta(X, l2id, T, vy)
+```
+
+## Authors
+
+Steven Andrew Culpepper and Herman Aguinis
+
+## Citing the `iccbeta` package
+
+To ensure future development of the package, please cite `iccbeta`
+package if used during an analysis or simulation studies. Citation
+information for the package may be acquired by using in *R*:
+
+``` r
+citation("iccbeta")
+```
+
+## License
+
+GPL (\>= 2)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,7 @@
 ## Test environments
 
-- local OS X install, R 3.4.1
-- ubuntu 12.04 (on travis-ci), R 3.4.1
+- local OS X install, R 3.5.2
+- ubuntu 14.04 (on travis-ci), R 3.5.2
 - win-builder (devel and release)
 
 ## R CMD check results

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,13 +1,29 @@
-citHeader("To cite package iccbeta in publications use:")
+citHeader("To cite the package 'iccbeta' in publications use:")
 
-citEntry(entry="Article",
-      title = "An expanded decision making procedure for examining cross-level interaction effects with multilevel modeling",
-         author = personList(as.person("Herman Aguinis"),
-         as.person("Steven Andrew Culpepper")),
-	 journal = "Organization Research Methods",
-         year = "2015",
-         url = "http://www.hermanaguinis.com/pubs.html",
-         pdf = "http://www.hermanaguinis.com/ORM2015.pdf",
-         doi = "10.1177/1094428114563618",
-         textVersion = "Agunis, H. & Culpepper, S. A. (2015). An expanded decision making procedure for examining cross-level interaction effects with multilevel modeling. Organizational Research Methods.")
+citEntry(entry = "Manual",
+         title        = "{iccbeta: Multilevel Model Intraclass Correlation for Slope Heterogeneity}",
+         author       = personList(as.person("Steven Andrew Culpepper"),
+                                   as.person("Herman Agunis")
+                                  ),
+         year         = 2015,
+         textVersion  = paste("Culpepper, S. A. and Agunis, H. (2015).",
+                              "iccbeta: Multilevel Model Intraclass Correlation for Slope Heterogeneity.",
+                              "URL https://cran.r-project.org/package=iccbeta.")
+)
+
+citEntry(
+    entry   = "Article",
+    title   = "An expanded decision making procedure for examining cross-level interaction effects with multilevel modeling",
+    author  = personList(as.person("Herman Aguinis"), 
+                        as.person("Steven Andrew Culpepper")),
+	journal = "Organization Research Methods",
+    year    = "2015",
+    url     = "http://www.hermanaguinis.com/pubs.html",
+    pdf     = "http://www.hermanaguinis.com/ORM2015.pdf",
+    doi     = "10.1177/1094428114563618",
+    textVersion = paste0("Agunis, H. & Culpepper, S. A. (2015).",
+                         " An expanded decision making procedure for examining",
+                         " cross-level interaction effects with multilevel",
+                         " modeling. Organizational Research Methods.")
+)
 

--- a/man/Hofmann.Rd
+++ b/man/Hofmann.Rd
@@ -6,13 +6,13 @@
 \title{A multilevel dataset from Hofmann, Griffin, and Gavin (2000).}
 \format{A data frame with 1,000 observations and 7 variables.
 \describe{
-    \item{\code{id}}{a numeric vector of group ids.}
-    \item{\code{helping}}{a numeric vector of the helping outcome variable construct.}
-    \item{\code{mood}}{a level 1 mood predictor.}
-    \item{\code{mood_grp_mn}}{a level 2 variable of the group mean of mood.}
-    \item{\code{cohesion}}{a level 2 covariate measuring cohesion.}
-    \item{\code{mood_grp_cent}}{group-mean centered mood predictor.}
-    \item{\code{mood_grd_cent}}{grand-mean centered mood predictor.}
+\item{\code{id}}{a numeric vector of group ids.}
+\item{\code{helping}}{a numeric vector of the helping outcome variable construct.}
+\item{\code{mood}}{a level 1 mood predictor.}
+\item{\code{mood_grp_mn}}{a level 2 variable of the group mean of mood.}
+\item{\code{cohesion}}{a level 2 covariate measuring cohesion.}
+\item{\code{mood_grp_cent}}{group-mean centered mood predictor.}
+\item{\code{mood_grd_cent}}{grand-mean centered mood predictor.}
 }}
 \source{
 Hofmann, D.A., Griffin, M.A., & Gavin, M.B. (2000). The application of hierarchical linear modeling to management research. In K.J. Klein, & S.W.J. Kozlowski (Eds.), Multilevel theory, research, and methods in organizations: Foundations, extensions, and new directions (pp. 467-511).  Hoboken, NJ: Jossey-Bass.
@@ -70,7 +70,7 @@ Available at: \url{http://hermanaguinis.com/pubs.html}
 }
 \seealso{
 \code{\link[lme4]{lmer}}, \code{\link{model.matrix}},
-         \code{\link[lme4]{VarCorr}}, \code{\link[RLRsim]{LRTSim}},
-         \code{\link{simICCdata}}
+\code{\link[lme4]{VarCorr}}, \code{\link[RLRsim]{LRTSim}},
+\code{\link{simICCdata}}
 }
 \keyword{datasets}

--- a/man/icc_beta.Rd
+++ b/man/icc_beta.Rd
@@ -10,8 +10,8 @@ icc_beta(X, l2id, T, vy)
 \arguments{
 \item{X}{The design \code{matrix} of fixed effects from a lmer model.}
 
-\item{l2id}{A \code{vector} that identifies group membership. The vector 
-must be coded as a sequence of integers from 1 to J, 
+\item{l2id}{A \code{vector} that identifies group membership. The vector
+must be coded as a sequence of integers from 1 to J,
 the number of groups.}
 
 \item{T}{A \code{matrix} of the estimated variance-covariance matrix of
@@ -20,7 +20,14 @@ a lmer model fit.}
 \item{vy}{The variance of the outcome variable.}
 }
 \value{
-vy  The variance of the dependent variable.
+A \code{list} with:
+\itemize{
+\item \code{J}
+\item \code{means}
+\item \code{XcpXc}
+\item \code{Nj}
+\item \code{rho_beta}
+}
 }
 \description{
 A function and vignettes for computing the intraclass correlation described
@@ -31,11 +38,11 @@ higher-order processes/units.
 \examples{
 \dontrun{
 
-if(requireNamespace("lme4") && requireNamespace("RLRsim")){ 
+if(requireNamespace("lme4") && requireNamespace("RLRsim")){
 # Simulated Data Example from Aguinis & Culpepper (2015)
 data(simICCdata)
 library("lme4")
-    
+
 # Computing icca
 vy <- var(simICCdata$Y)
 lmm0 <- lmer(Y ~ (1 | l2id), data = simICCdata, REML = FALSE)
@@ -45,10 +52,12 @@ VarCorr(lmm0)$l2id[1, 1]/vy
 grp_means = aggregate(simICCdata[c('X1', 'X2')], simICCdata['l2id'], mean)
 colnames(grp_means)[2:3] = c('m_X1', 'm_X2')
 simICCdata2 = merge(simICCdata, grp_means, by='l2id')
-        
+
 # Estimating random slopes model
-lmm1  <- lmer(Y ~ I(X1-m_X1) + I(X2-m_X2) + (I(X1-m_X1) + I(X2-m_X2) | l2id),
-                      data = simICCdata2, REML = FALSE)
+lmm1  <- lmer(Y ~ I(X1 - m_X1) + I(X2 - m_X2) + 
+                 (I(X1 - m_X1) + I(X2 - m_X2) | l2id),
+              data = simICCdata2, REML = FALSE)
+                  
 X <- model.matrix(lmm1)
 p <- ncol(X)
 T1  <- VarCorr(lmm1)$l2id[1:p,1:p]
@@ -56,18 +65,18 @@ T1  <- VarCorr(lmm1)$l2id[1:p,1:p]
 # Computing iccb
 # Notice '+1' because icc_beta assumes l2ids are from 1 to 30.
 icc_beta(X, simICCdata2$l2id+1, T1, vy)$rho_beta
-            
+
 # Hofmann et al. (2000) Example
 data(Hofmann)
 library("lme4")
-                
+
 # Random-Intercepts Model
 lmmHofmann0 = lmer(helping ~ (1|id), data = Hofmann)
 vy_Hofmann = var(Hofmann[,'helping'])
 
 # Computing icca
 VarCorr(lmmHofmann0)$id[1,1]/vy_Hofmann
-                    
+
 # Estimating Group-Mean Centered Random Slopes Model, no level 2 variables
 lmmHofmann1 <- lmer(helping ~ mood_grp_cent + (mood_grp_cent |id),
                     data = Hofmann, REML = FALSE)
@@ -77,10 +86,10 @@ T1_Hofmann <- VarCorr(lmmHofmann1)$id[1:P,1:P]
 
 # Computing iccb
 icc_beta(X_Hofmann, Hofmann[,'id'], T1_Hofmann, vy_Hofmann)$rho_beta
-                        
+
 # Performing LR test
 library("RLRsim")
-lmmHofmann1a <- lmer(helping ~ mood_grp_cent + (1 |id), 
+lmmHofmann1a <- lmer(helping ~ mood_grp_cent + (1 |id),
                      data = Hofmann, REML = FALSE)
 obs.LRT <- 2*(logLik(lmmHofmann1) - logLik(lmmHofmann1a))[1]
 X <- getME(lmmHofmann1,"X")
@@ -88,9 +97,9 @@ Z <- t(as.matrix(getME(lmmHofmann1,"Zt")))
 sim.LRT <- LRTSim(X, Z, 0, diag(ncol(Z)))
 (pval <- mean(sim.LRT > obs.LRT))
 } else {
- stop("Please install packages `RLRsim` and `lme4` to run the above example.")
+ stop("Please install packages `RLRsim` and `lme4` to run the above example.") 
+} 
 }
-}  
 }
 \references{
 Aguinis, H., & Culpepper, S.A. (2015). An expanded decision making
@@ -99,10 +108,10 @@ modeling. \emph{Organizational Research Methods}. Available at:
 \url{http://hermanaguinis.com/pubs.html}
 }
 \seealso{
-\code{\link[lme4]{lmer}}, \code{\link{model.matrix}},
-         \code{\link[lme4]{VarCorr}}, \code{\link[RLRsim]{LRTSim}},
-         \code{\link{Hofmann}}, \code{\link{simICCdata}}
+\code{\link[lme4:lmer]{lme4::lmer()}}, \code{\link[=model.matrix]{model.matrix()}},
+\code{\link[lme4:VarCorr]{lme4::VarCorr()}}, \code{\link[RLRsim:LRTSim]{RLRsim::LRTSim()}},
+\link[iccbeta:Hofmann]{iccbeta::Hofmann}, and \link[iccbeta:simICCdata]{iccbeta::simICCdata}
 }
 \author{
-Steven A Culpepper
+Steven Andrew Culpepper
 }

--- a/man/iccbeta-package.Rd
+++ b/man/iccbeta-package.Rd
@@ -7,9 +7,9 @@
 \title{iccbeta: Multilevel Model Intraclass Correlation for Slope Heterogeneity}
 \description{
 A function and vignettes for computing an intraclass correlation
-described in Aguinis & Culpepper (2015) <doi:10.1177/1094428114563618>.
-This package quantifies the share of variance in a dependent variable that
-is attributed to group heterogeneity in slopes.
+    described in Aguinis & Culpepper (2015) <doi:10.1177/1094428114563618>.
+    This package quantifies the share of variance in a dependent variable that
+    is attributed to group heterogeneity in slopes.
 }
 \examples{
 \dontrun{
@@ -88,11 +88,11 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Steven Andrew Culpepper \email{sculpepp@illinois.edu} [copyright holder]
+\strong{Maintainer}: Steven Andrew Culpepper \email{sculpepp@illinois.edu} (0000-0003-4226-6176) [copyright holder]
 
 Authors:
 \itemize{
-  \item Herman Aguinis \email{haguinis@gwu.edu} [copyright holder]
+  \item Herman Aguinis \email{haguinis@gwu.edu} (0000-0002-3485-9484) [copyright holder]
 }
 
 }

--- a/man/simICCdata.Rd
+++ b/man/simICCdata.Rd
@@ -4,15 +4,15 @@
 \name{simICCdata}
 \alias{simICCdata}
 \title{Simulated data example from Aguinis and Culpepper (2015).}
-\format{A data frame with 900 observations (i.e., 30 observations nested 
+\format{A data frame with 900 observations (i.e., 30 observations nested
 within 30 groups) on the following 6 variables.
 \describe{
-    \item{\code{l1id}}{A within group ID variable.}
-    \item{\code{l2id}}{A group ID variable.}
-    \item{\code{one}}{A column of 1's for the intercept.}
-    \item{\code{X1}}{A simulated level 1 predictor.}
-    \item{\code{X2}}{A simulated level 1 predictor.}
-    \item{\code{Y}}{A simulated outcome variable.}
+\item{\code{l1id}}{A within group ID variable.}
+\item{\code{l2id}}{A group ID variable.}
+\item{\code{one}}{A column of 1's for the intercept.}
+\item{\code{X1}}{A simulated level 1 predictor.}
+\item{\code{X2}}{A simulated level 1 predictor.}
+\item{\code{Y}}{A simulated outcome variable.}
 }}
 \source{
 Aguinis, H., & Culpepper, S.A. (2015). An expanded decision
@@ -64,7 +64,7 @@ icc_beta(X, simICCdata2$l2id+1, T1, vy)$rho_beta
 }
 \seealso{
 \code{\link[lme4]{lmer}}, \code{\link{model.matrix}},
-         \code{\link[lme4]{VarCorr}}, \code{\link[RLRsim]{LRTSim}},
-         \code{\link{Hofmann}}
+\code{\link[lme4]{VarCorr}}, \code{\link[RLRsim]{LRTSim}},
+\code{\link{Hofmann}}
 }
 \keyword{datasets}

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,25 @@
+################################################################################
+# James Joseph Balamuta
+# balamut2@illinois.edu
+################################################################################
+# All cpp files should be formatted according to the style rules
+# enforced by this file using clang-format.
+#
+# Official style options documentation:
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+# Style options with interactive examples:
+# https://clangformat.com/
+################################################################################
+### Example use
+# shopt -s extglob
+# clang-format -i -style=file src/!(RcppExports).@(c|h|cpp) 
+#
+################################################################################
+BasedOnStyle: LLVM
+IndentWidth: 4
+AlignTrailingComments: true
+UseTab: Never
+BreakBeforeBraces: Linux
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,1 +1,8 @@
-PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+# Enable C++11
+CXX_STD=CXX11
+
+# Enable the header file and OpenMP
+PKG_CXXFLAGS=-I../inst/include $(SHLIB_OPENMP_CXXFLAGS) 
+
+# Specify the required linking setup
+PKG_LIBS=$(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,2 +1,8 @@
+# Enable C++11
+CXX_STD=CXX11
 
-PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+# Enable the header file and OpenMP
+PKG_CXXFLAGS=-I../inst/include $(SHLIB_OPENMP_CXXFLAGS) 
+
+# Specify the required linking setup
+PKG_LIBS=$(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/icc_beta.cpp
+++ b/src/icc_beta.cpp
@@ -107,40 +107,41 @@
 //' } 
 //' }
 // [[Rcpp::export]]
-Rcpp::List icc_beta(const arma::mat& X, const arma::vec& l2id,
-                    const arma::mat& T, double vy) {
-    
-  unsigned int N = l2id.n_elem;
-  unsigned int p = X.n_cols;
-  unsigned int J=max(l2id);
-  arma::mat SUMS = arma::zeros<arma::mat>(J,p);
-  arma::mat means = arma::zeros<arma::mat>(J,p);
-  arma::vec Nj = arma::zeros<arma::vec>(J);
-  arma::vec ONE = arma::ones<arma::vec>(N);
-  
-  for(unsigned int i=0;i<N;i++){
-    //assume l2id goes from 0 to J-1
-    Nj(l2id(i)-1) += ONE(i);
-    SUMS.row(l2id(i)-1) += X.row(i);
-  }
-  
-  for(unsigned int j=0;j<J;j++){
-    if(Nj(j)>0.0){
-      means.row(j) = SUMS.row(j)/Nj(j);
+Rcpp::List icc_beta(const arma::mat &X, const arma::vec &l2id,
+                    const arma::mat &T, double vy)
+{
+
+    unsigned int N = l2id.n_elem;
+    unsigned int p = X.n_cols;
+    unsigned int J = max(l2id);
+    arma::mat SUMS = arma::zeros<arma::mat>(J, p);
+    arma::mat means = arma::zeros<arma::mat>(J, p);
+    arma::vec Nj = arma::zeros<arma::vec>(J);
+    arma::vec ONE = arma::ones<arma::vec>(N);
+
+    for (unsigned int i = 0; i < N; ++i) {
+        // assume l2id goes from 0 to J-1
+        Nj(l2id(i) - 1) += ONE(i);
+        SUMS.row(l2id(i) - 1) += X.row(i);
     }
-  }
 
-  arma::mat XcpXc = arma::zeros<arma::mat>(p,p);
-  for(unsigned int i=0;i<N;i++){
-    XcpXc += ( X.row(i) - means.row(l2id(i)-1) ).t() * ( X.row(i) - means.row(l2id(i)-1) );
-  }
+    for (unsigned int j = 0; j < J; ++j) {
+        if (Nj(j) > 0.0) {
+            means.row(j) = SUMS.row(j) / Nj(j);
+        }
+    }
 
-  double rho_beta = trace(T * XcpXc/(sum(Nj)-1.0))/vy;  
-  
-  return Rcpp::List::create(Rcpp::Named("J",J),
-                            Rcpp::Named("means",means),
-                            Rcpp::Named("XcpXc",XcpXc),
-                            Rcpp::Named("Nj",Nj),
-                            Rcpp::Named("rho_beta",rho_beta)
-                            );
+    arma::mat XcpXc = arma::zeros<arma::mat>(p, p);
+    for (unsigned int i = 0; i < N; ++i) {
+        XcpXc += (X.row(i) - means.row(l2id(i) - 1)).t() *
+                 (X.row(i) - means.row(l2id(i) - 1));
+    }
+
+    double rho_beta = trace(T * XcpXc / (sum(Nj) - 1.0)) / vy;
+
+    return Rcpp::List::create(Rcpp::Named("J", J),
+                              Rcpp::Named("means", means),
+                              Rcpp::Named("XcpXc", XcpXc),
+                              Rcpp::Named("Nj", Nj),
+                              Rcpp::Named("rho_beta", rho_beta));
 }

--- a/src/icc_beta.cpp
+++ b/src/icc_beta.cpp
@@ -2,82 +2,100 @@
 
 //' Intraclass correlation used to assess variability of lower-order
 //' relationships across higher-order processes/units.
-//' 
+//'
 //' A function and vignettes for computing the intraclass correlation described
 //' in Aguinis & Culpepper (2015). iccbeta quantifies the share of variance
 //' in an outcome variable that is attributed to heterogeneity in slopes due to
-//' higher-order processes/units. 
-//' @param X    The design \code{matrix} of fixed effects from a lmer model.
-//' @param l2id A \code{vector} that identifies group membership. The vector 
-//'             must be coded as a sequence of integers from 1 to J, 
+//' higher-order processes/units.
+//' 
+//' @param X    The design `matrix` of fixed effects from a lmer model.
+//' @param l2id A `vector` that identifies group membership. The vector
+//'             must be coded as a sequence of integers from 1 to J,
 //'             the number of groups.
-//' @param T    A \code{matrix} of the estimated variance-covariance matrix of
+//' @param T    A `matrix` of the estimated variance-covariance matrix of
 //'             a lmer model fit.
 //' @param vy   The variance of the outcome variable.
-//' @return vy  The variance of the dependent variable.
-//' @author Steven A Culpepper
-//' @seealso \code{\link[lme4]{lmer}}, \code{\link{model.matrix}},
-//'          \code{\link[lme4]{VarCorr}}, \code{\link[RLRsim]{LRTSim}},
-//'          \code{\link{Hofmann}}, \code{\link{simICCdata}}
-//' @references 
+//' 
+//' @return 
+//' A `list` with:
+//' 
+//' - `J`
+//' - `means`
+//' - `XcpXc`
+//' - `Nj`
+//' - `rho_beta`
+//' 
+//' @author 
+//' Steven Andrew Culpepper
+//' 
+//' @seealso 
+//' 
+//' [lme4::lmer()], [model.matrix()],
+//' [lme4::VarCorr()], [RLRsim::LRTSim()],
+//' [iccbeta::Hofmann], and [iccbeta::simICCdata]
+//'          
+//' @references
 //' Aguinis, H., & Culpepper, S.A. (2015). An expanded decision making
 //' procedure for examining cross-level interaction effects with multilevel
-//' modeling. \emph{Organizational Research Methods}. Available at:
-//' \url{http://hermanaguinis.com/pubs.html}
+//' modeling. _Organizational Research Methods_. Available at:
+//' <http://hermanaguinis.com/pubs.html>
+//' 
 //' @export
 //' @examples
 //' \dontrun{
-//' 
-//' if(requireNamespace("lme4") && requireNamespace("RLRsim")){ 
+//'
+//' if(requireNamespace("lme4") && requireNamespace("RLRsim")){
 //' # Simulated Data Example from Aguinis & Culpepper (2015)
 //' data(simICCdata)
 //' library("lme4")
-//'     
+//'
 //' # Computing icca
 //' vy <- var(simICCdata$Y)
 //' lmm0 <- lmer(Y ~ (1 | l2id), data = simICCdata, REML = FALSE)
 //' VarCorr(lmm0)$l2id[1, 1]/vy
-//' 
+//'
 //' # Create simICCdata2
 //' grp_means = aggregate(simICCdata[c('X1', 'X2')], simICCdata['l2id'], mean)
 //' colnames(grp_means)[2:3] = c('m_X1', 'm_X2')
 //' simICCdata2 = merge(simICCdata, grp_means, by='l2id')
-//'         
+//'
 //' # Estimating random slopes model
-//' lmm1  <- lmer(Y ~ I(X1-m_X1) + I(X2-m_X2) + (I(X1-m_X1) + I(X2-m_X2) | l2id),
-//'                       data = simICCdata2, REML = FALSE)
+//' lmm1  <- lmer(Y ~ I(X1 - m_X1) + I(X2 - m_X2) + 
+//'                  (I(X1 - m_X1) + I(X2 - m_X2) | l2id),
+//'               data = simICCdata2, REML = FALSE)
+//'                   
 //' X <- model.matrix(lmm1)
 //' p <- ncol(X)
 //' T1  <- VarCorr(lmm1)$l2id[1:p,1:p]
-//' 
+//'
 //' # Computing iccb
 //' # Notice '+1' because icc_beta assumes l2ids are from 1 to 30.
 //' icc_beta(X, simICCdata2$l2id+1, T1, vy)$rho_beta
-//'             
+//'
 //' # Hofmann et al. (2000) Example
 //' data(Hofmann)
 //' library("lme4")
-//'                 
+//'
 //' # Random-Intercepts Model
 //' lmmHofmann0 = lmer(helping ~ (1|id), data = Hofmann)
 //' vy_Hofmann = var(Hofmann[,'helping'])
-//' 
+//'
 //' # Computing icca
 //' VarCorr(lmmHofmann0)$id[1,1]/vy_Hofmann
-//'                     
+//'
 //' # Estimating Group-Mean Centered Random Slopes Model, no level 2 variables
 //' lmmHofmann1 <- lmer(helping ~ mood_grp_cent + (mood_grp_cent |id),
 //'                     data = Hofmann, REML = FALSE)
 //' X_Hofmann <- model.matrix(lmmHofmann1)
 //' P <- ncol(X_Hofmann)
 //' T1_Hofmann <- VarCorr(lmmHofmann1)$id[1:P,1:P]
-//' 
+//'
 //' # Computing iccb
 //' icc_beta(X_Hofmann, Hofmann[,'id'], T1_Hofmann, vy_Hofmann)$rho_beta
-//'                         
+//'
 //' # Performing LR test
 //' library("RLRsim")
-//' lmmHofmann1a <- lmer(helping ~ mood_grp_cent + (1 |id), 
+//' lmmHofmann1a <- lmer(helping ~ mood_grp_cent + (1 |id),
 //'                      data = Hofmann, REML = FALSE)
 //' obs.LRT <- 2*(logLik(lmmHofmann1) - logLik(lmmHofmann1a))[1]
 //' X <- getME(lmmHofmann1,"X")
@@ -85,9 +103,9 @@
 //' sim.LRT <- LRTSim(X, Z, 0, diag(ncol(Z)))
 //' (pval <- mean(sim.LRT > obs.LRT))
 //' } else {
-//'  stop("Please install packages `RLRsim` and `lme4` to run the above example.")
+//'  stop("Please install packages `RLRsim` and `lme4` to run the above example.") 
+//' } 
 //' }
-//' }  
 // [[Rcpp::export]]
 Rcpp::List icc_beta(const arma::mat& X, const arma::vec& l2id,
                     const arma::mat& T, double vy) {

--- a/src/icc_beta.cpp
+++ b/src/icc_beta.cpp
@@ -110,6 +110,10 @@
 Rcpp::List icc_beta(const arma::mat &X, const arma::vec &l2id,
                     const arma::mat &T, double vy)
 {
+  
+    if(!X.is_finite()) {
+      Rcpp::stop("`X` must not have any missing values (NA).");
+    }
 
     unsigned int N = l2id.n_elem;
     unsigned int p = X.n_cols;


### PR DESCRIPTION
Within this PR, we:

- Standardize README file
- Format code
- Improve documentation
- Enable C++11 and OpenMP
- Update dependencies.
- Added finiteness check on the design matrix (`X`) in `icc_beta()` (close #3).

/cc @steveculpepper 